### PR TITLE
feat: enhance admin console features

### DIFF
--- a/components/admin/InviteUserDialog.tsx
+++ b/components/admin/InviteUserDialog.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../ui/Dialog';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Select, SelectItem, SelectValue } from '../ui/Select';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '../ui/Form';
+import { UserRole } from '../../types';
+
+const inviteUserSchema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters long.'),
+  email: z.string().email('Enter a valid email address.'),
+  role: z.nativeEnum(UserRole),
+});
+
+type InviteUserSchema = z.infer<typeof inviteUserSchema>;
+
+const roleOptions: { label: string; value: UserRole; description: string }[] = [
+  { label: 'Administrator', value: UserRole.ADMIN, description: 'Full access to settings and data.' },
+  { label: 'Staff', value: UserRole.STAFF, description: 'Manage operations without system settings.' },
+  { label: 'Viewer', value: UserRole.VIEWER, description: 'Read-only access to dashboards.' },
+];
+
+interface InviteUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (values: InviteUserSchema) => void;
+  isSubmitting?: boolean;
+}
+
+export const InviteUserDialog: React.FC<InviteUserDialogProps> = ({ open, onOpenChange, onSubmit, isSubmitting }) => {
+  const form = useForm<InviteUserSchema>({
+    resolver: zodResolver(inviteUserSchema),
+    defaultValues: { name: '', email: '', role: UserRole.STAFF },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      form.reset({ name: '', email: '', role: UserRole.STAFF });
+    }
+  }, [open, form]);
+
+  const handleSubmit = form.handleSubmit(values => {
+    onSubmit(values);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite new team member</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Full name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Jane Doe" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email address</FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="jane@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onChange={event => field.onChange(event.target.value as UserRole)}>
+                      <SelectValue placeholder="Select role" />
+                      {roleOptions.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                  <p className="text-xs text-muted-foreground">
+                    {roleOptions.find(option => option.value === field.value)?.description}
+                  </p>
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Sending invite…' : 'Send invite'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export type { InviteUserSchema };

--- a/components/admin/UserRoleSelect.tsx
+++ b/components/admin/UserRoleSelect.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { Select, SelectItem } from '../ui/Select';
+import { Badge } from '../ui/Badge';
+import { UserRole } from '../../types';
+
+const roleLabels: Record<UserRole, string> = {
+  [UserRole.ADMIN]: 'Admin',
+  [UserRole.STAFF]: 'Staff',
+  [UserRole.VIEWER]: 'Viewer',
+};
+
+const roleBadgeVariant: Record<UserRole, 'default' | 'secondary' | 'outline'> = {
+  [UserRole.ADMIN]: 'default',
+  [UserRole.STAFF]: 'secondary',
+  [UserRole.VIEWER]: 'outline',
+};
+
+interface UserRoleSelectProps {
+  value: UserRole;
+  onChange: (role: UserRole) => void;
+  disabled?: boolean;
+}
+
+export const UserRoleSelect: React.FC<UserRoleSelectProps> = ({ value, onChange, disabled }) => {
+  return (
+    <div className="flex items-center gap-3">
+      <Badge variant={roleBadgeVariant[value]}>{roleLabels[value]}</Badge>
+      <Select
+        value={value}
+        onChange={event => onChange(event.target.value as UserRole)}
+        disabled={disabled}
+        className="max-w-[140px]"
+      >
+        {Object.values(UserRole).map(role => (
+          <SelectItem key={role} value={role}>
+            {roleLabels[role]}
+          </SelectItem>
+        ))}
+      </Select>
+    </div>
+  );
+};

--- a/pages/admin/AdminPage.tsx
+++ b/pages/admin/AdminPage.tsx
@@ -1,63 +1,375 @@
-import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/Card';
+import React, { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/Card';
 import { Badge } from '../../components/ui/Badge';
 import { Button } from '../../components/ui/Button';
+import { Skeleton } from '../../components/ui/Skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table';
+import { InviteUserDialog, type InviteUserSchema } from '../../components/admin/InviteUserDialog';
+import { UserRoleSelect } from '../../components/admin/UserRoleSelect';
+import { adminApi } from '../../services/api';
+import type {
+  AuditLogEntry,
+  HealthCheckResult,
+  SystemOverview,
+  User,
+  UserRole,
+} from '../../types';
+
+const statusColorMap: Record<'success' | 'warning' | 'error', 'default' | 'secondary' | 'destructive'> = {
+  success: 'secondary',
+  warning: 'default',
+  error: 'destructive',
+};
+
+const healthStatusStyles: Record<HealthCheckResult['overallStatus'], string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  degraded: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  critical: 'bg-destructive/15 text-destructive',
+};
+
+const formatDate = (isoDate?: string) => {
+  if (!isoDate) {
+    return '—';
+  }
+  const date = new Date(isoDate);
+  return date.toLocaleString();
+};
+
+const relativeTime = (isoDate?: string) => {
+  if (!isoDate) {
+    return 'Never';
+  }
+  const now = Date.now();
+  const diff = now - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / (1000 * 60));
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr${hours > 1 ? 's' : ''} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days > 1 ? 's' : ''} ago`;
+};
+
+const serviceStatusBadge: Record<'operational' | 'degraded' | 'offline', { label: string; className: string }> = {
+  operational: { label: 'Operational', className: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
+  degraded: { label: 'Degraded', className: 'bg-amber-500/10 text-amber-600 dark:text-amber-400' },
+  offline: { label: 'Offline', className: 'bg-destructive/10 text-destructive' },
+};
 
 const AdminPage: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [latestHealthResult, setLatestHealthResult] = useState<HealthCheckResult | null>(null);
+
+  const { data: systemOverview, isLoading: systemLoading } = useQuery<SystemOverview>({
+    queryKey: ['admin', 'system-overview'],
+    queryFn: () => adminApi.getSystemOverview(),
+  });
+
+  const {
+    data: users,
+    isLoading: usersLoading,
+    isFetching: usersRefreshing,
+  } = useQuery<User[]>({
+    queryKey: ['admin', 'users'],
+    queryFn: () => adminApi.getUsers(),
+  });
+
+  const { data: auditLogs, isLoading: logsLoading } = useQuery<AuditLogEntry[]>({
+    queryKey: ['admin', 'audit-logs'],
+    queryFn: () => adminApi.getAuditLogs(),
+  });
+
+  const inviteMutation = useMutation({
+    mutationFn: (payload: InviteUserSchema) => adminApi.inviteUser(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+      setInviteOpen(false);
+    },
+  });
+
+  const updateRoleMutation = useMutation({
+    mutationFn: ({ userId, role }: { userId: string; role: UserRole }) =>
+      adminApi.updateUserRole({ userId, role }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+
+  const healthCheckMutation = useMutation({
+    mutationFn: () => adminApi.runHealthCheck(),
+    onSuccess: result => {
+      setLatestHealthResult(result);
+      queryClient.invalidateQueries({ queryKey: ['admin', 'audit-logs'] });
+    },
+  });
+
+  const systemStats = useMemo(() => {
+    if (!systemOverview) return null;
+    return [
+      { label: 'Uptime', value: `${systemOverview.uptime.toFixed(2)}%` },
+      { label: 'Version', value: systemOverview.version },
+      { label: 'Incidents', value: systemOverview.incidentsOpen },
+      { label: 'Next Maintenance', value: new Date(systemOverview.nextMaintenance).toLocaleDateString() },
+      { label: 'Environment', value: systemOverview.environment },
+    ];
+  }, [systemOverview]);
+
+  const effectiveHealth = latestHealthResult ?? null;
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Admin</h1>
-          <p className="text-muted-foreground">Administrative tools and system controls</p>
+          <h1 className="text-2xl font-bold tracking-tight">Admin Console</h1>
+          <p className="text-muted-foreground">Control centre for teams, infrastructure and security</p>
         </div>
-        <Badge variant="secondary">ADMIN</Badge>
+        <div className="flex items-center gap-2">
+          {usersRefreshing && <Badge variant="secondary">Syncing data…</Badge>}
+          <Badge variant="secondary">ADMIN</Badge>
+        </div>
       </div>
 
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {systemLoading && (
+          <>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={index}>
+                <CardHeader className="space-y-2">
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-8 w-16" />
+                </CardHeader>
+              </Card>
+            ))}
+          </>
+        )}
+        {systemStats?.map(stat => (
+          <Card key={stat.label}>
+            <CardHeader>
+              <CardDescription>{stat.label}</CardDescription>
+              <CardTitle className="text-3xl">{stat.value}</CardTitle>
+            </CardHeader>
+          </Card>
+        ))}
+        {effectiveHealth && (
+          <Card>
+            <CardHeader>
+              <CardDescription>Last health check</CardDescription>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <span className={`rounded-full px-2 py-1 text-sm font-medium ${healthStatusStyles[effectiveHealth.overallStatus]}`}>
+                  {effectiveHealth.overallStatus.toUpperCase()}
+                </span>
+                <span className="text-sm font-normal text-muted-foreground">{relativeTime(effectiveHealth.checkedAt)}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {effectiveHealth.results.map(result => (
+                <div key={result.name} className="flex items-start justify-between gap-4 text-sm">
+                  <div>
+                    <p className="font-medium">{result.name}</p>
+                    <p className="text-muted-foreground">{result.message}</p>
+                  </div>
+                  <Badge variant={result.passed ? 'secondary' : 'destructive'}>
+                    {result.passed ? 'Pass' : 'Attention'}
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
         <Card>
-          <CardHeader>
-            <CardTitle>Users</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">Manage roles and access</p>
-            <div className="flex gap-2">
-              <Button size="sm">Invite User</Button>
-              <Button size="sm" variant="secondary">View All</Button>
+          <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <CardTitle className="text-xl">Team members</CardTitle>
+              <CardDescription>Manage access for everyone working in the console</CardDescription>
             </div>
+            <Button size="sm" onClick={() => setInviteOpen(true)}>
+              Invite user
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {usersLoading ? (
+              <div className="space-y-4">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <div key={index} className="flex items-center justify-between">
+                    <Skeleton className="h-10 w-[220px]" />
+                    <Skeleton className="h-10 w-[140px]" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {users?.map(user => (
+                  <div
+                    key={user.id}
+                    className="flex flex-col gap-4 rounded-md border p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold">{user.name}</p>
+                      <p className="text-sm text-muted-foreground">{user.email}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {user.status === 'invited' ? 'Invitation pending' : `Last active ${relativeTime(user.lastActive)}`}
+                      </p>
+                    </div>
+                    <UserRoleSelect
+                      value={user.role}
+                      disabled={updateRoleMutation.isPending && updateRoleMutation.variables?.userId === user.id}
+                      onChange={role => updateRoleMutation.mutate({ userId: user.id, role })}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>System</CardTitle>
+          <CardHeader className="flex flex-col gap-2">
+            <CardTitle className="text-xl">Run diagnostics</CardTitle>
+            <CardDescription>Check integrations and infrastructure health in real time</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">Configuration and maintenance</p>
-            <div className="flex gap-2">
-              <Button size="sm">Run Health Check</Button>
-              <Button size="sm" variant="secondary">View Logs</Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Security</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">Audit and compliance</p>
-            <div className="flex gap-2">
-              <Button size="sm">Audit Trail</Button>
-              <Button size="sm" variant="secondary">Access Policies</Button>
+            <Button
+              className="w-full"
+              onClick={() => healthCheckMutation.mutate()}
+              disabled={healthCheckMutation.isPending}
+            >
+              {healthCheckMutation.isPending ? 'Running health check…' : 'Run health check'}
+            </Button>
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Last executed</span>
+                <span>{effectiveHealth ? formatDate(effectiveHealth.checkedAt) : 'Not run yet'}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Environment</span>
+                <span className="font-medium uppercase">{systemOverview?.environment ?? '—'}</span>
+              </div>
             </div>
           </CardContent>
         </Card>
       </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.3fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Service status</CardTitle>
+            <CardDescription>Live overview of platform services and SLAs</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {systemOverview ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Service</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Response time</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {systemOverview.services.map(service => (
+                    <TableRow key={service.name}>
+                      <TableCell>
+                        <div>
+                          <p className="font-medium">{service.name}</p>
+                          {service.dependency && (
+                            <p className="text-xs text-muted-foreground">Depends on {service.dependency}</p>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${serviceStatusBadge[service.status].className}`}>
+                          {serviceStatusBadge[service.status].label}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-muted-foreground">
+                        {service.responseTimeMs} ms
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <Skeleton key={index} className="h-10 w-full" />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-start justify-between">
+            <div>
+              <CardTitle className="text-xl">Audit log</CardTitle>
+              <CardDescription>Track sensitive operations inside the console</CardDescription>
+            </div>
+            <Badge variant="secondary">{auditLogs?.length ?? 0} events</Badge>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {logsLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <Skeleton key={index} className="h-12 w-full" />
+                ))}
+              </div>
+            ) : auditLogs && auditLogs.length > 0 ? (
+              <div className="space-y-3">
+                {auditLogs.slice(0, 6).map(log => (
+                  <div key={log.id} className="rounded-md border p-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium">{log.action}</p>
+                      <Badge variant={statusColorMap[log.status]} className="uppercase">
+                        {log.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+                      <span>{log.actor} → {log.target}</span>
+                      <span>{relativeTime(log.timestamp)}</span>
+                    </div>
+                    {log.ipAddress && (
+                      <p className="mt-1 text-xs text-muted-foreground">IP {log.ipAddress}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No audit events recorded.</p>
+            )}
+            <Button variant="secondary" className="w-full">
+              View full audit trail
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <InviteUserDialog
+        open={inviteOpen}
+        onOpenChange={setInviteOpen}
+        onSubmit={values => inviteMutation.mutate(values)}
+        isSubmitting={inviteMutation.isPending}
+      />
     </div>
   );
 };
 
 export default AdminPage;
-
-

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,13 +1,80 @@
 
-import { UserRole, type Order, type Product, type Customer, type User, type PaginatedResponse } from '../types';
+import {
+  UserRole,
+  type Order,
+  type Product,
+  type Customer,
+  type User,
+  type PaginatedResponse,
+  type SystemOverview,
+  type SystemServiceStatus,
+  type HealthCheckResult,
+  type AuditLogEntry,
+} from '../types';
 import { toast } from 'sonner';
 
 // --- MOCK DATABASE ---
 const users: User[] = [
-    { id: '1', name: 'Admin User', email: 'admin@gmail.com', role: UserRole.ADMIN, avatarUrl: 'https://i.pravatar.cc/150?u=admin' },
-    { id: '2', name: 'Staff User', email: 'staff@gmail.com', role: UserRole.STAFF, avatarUrl: 'https://i.pravatar.cc/150?u=staff' },
-    { id: '3', name: 'Viewer User', email: 'viewer@gmail.com', role: UserRole.VIEWER, avatarUrl: 'https://i.pravatar.cc/150?u=viewer' },
-]
+    {
+        id: '1',
+        name: 'Admin User',
+        email: 'admin@gmail.com',
+        role: UserRole.ADMIN,
+        avatarUrl: 'https://i.pravatar.cc/150?u=admin',
+        status: 'active',
+        lastActive: new Date().toISOString(),
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 90).toISOString(),
+    },
+    {
+        id: '2',
+        name: 'Staff User',
+        email: 'staff@gmail.com',
+        role: UserRole.STAFF,
+        avatarUrl: 'https://i.pravatar.cc/150?u=staff',
+        status: 'active',
+        lastActive: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 45).toISOString(),
+    },
+    {
+        id: '3',
+        name: 'Viewer User',
+        email: 'viewer@gmail.com',
+        role: UserRole.VIEWER,
+        avatarUrl: 'https://i.pravatar.cc/150?u=viewer',
+        status: 'active',
+        lastActive: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+    },
+];
+
+const systemServices: SystemServiceStatus[] = [
+    { name: 'API Gateway', status: 'operational', responseTimeMs: 182 },
+    { name: 'Authentication', status: 'operational', responseTimeMs: 146, dependency: 'Identity Provider' },
+    { name: 'Payments', status: 'degraded', responseTimeMs: 421, dependency: 'Stripe API' },
+    { name: 'Notifications', status: 'operational', responseTimeMs: 205, dependency: 'Firebase Cloud Messaging' },
+    { name: 'Reporting', status: 'operational', responseTimeMs: 264 },
+];
+
+const auditLogs: AuditLogEntry[] = Array.from({ length: 12 }, (_, index) => {
+    const timestamp = new Date(Date.now() - index * 1000 * 60 * 45).toISOString();
+    const actions = [
+        ['User Login', 'Admin User', 'self-service login', 'success'],
+        ['Role Updated', 'Admin User', 'Staff User', 'warning'],
+        ['Password Reset', 'Staff User', 'Viewer User', 'success'],
+        ['Export Data', 'Admin User', 'Orders', 'success'],
+        ['Failed Login', 'Viewer User', 'self-service login', 'error'],
+    ] as const;
+    const [action, actor, target, status] = actions[index % actions.length];
+    return {
+        id: `log-${index + 1}`,
+        action,
+        actor,
+        target,
+        timestamp,
+        status,
+        ipAddress: `10.0.0.${index + 10}`,
+    } satisfies AuditLogEntry;
+});
 
 const products: Product[] = Array.from({ length: 55 }, (_, i) => ({
     id: `PROD-${1001 + i}`,
@@ -149,9 +216,146 @@ export const customersApi = {
         c.email.toLowerCase().includes(q.toLowerCase())
       );
     }
-    
+
     const total = filteredCustomers.length;
     const data = filteredCustomers.slice((page - 1) * limit, page * limit);
     return { data, total, page, limit };
   },
+};
+
+// --- Admin Service ---
+const createAuditLog = (entry: Omit<AuditLogEntry, 'id' | 'timestamp'>) => {
+    const newEntry: AuditLogEntry = {
+        id: `log-${Date.now()}`,
+        timestamp: new Date().toISOString(),
+        ...entry,
+    };
+    auditLogs.unshift(newEntry);
+    return newEntry;
+};
+
+const computeHealthStatus = (results: HealthCheckResult['results']): HealthCheckResult['overallStatus'] => {
+    const totalFailures = results.filter(result => !result.passed).length;
+    if (totalFailures === 0) {
+        return 'healthy';
+    }
+    if (totalFailures === results.length || totalFailures > 2) {
+        return 'critical';
+    }
+    return 'degraded';
+};
+
+export const adminApi = {
+    getUsers: async (): Promise<User[]> => {
+        await sleep(400);
+        return [...users].sort((a, b) => a.name.localeCompare(b.name));
+    },
+    inviteUser: async (payload: { name: string; email: string; role: UserRole }): Promise<User> => {
+        await sleep(600);
+        const existingUser = users.find(user => user.email.toLowerCase() === payload.email.toLowerCase());
+        if (existingUser) {
+            toast.error('A user with this email already exists.');
+            throw new Error('User already exists');
+        }
+
+        const newUser: User = {
+            id: `user-${Date.now()}`,
+            name: payload.name,
+            email: payload.email,
+            role: payload.role,
+            status: 'invited',
+            createdAt: new Date().toISOString(),
+            lastActive: undefined,
+        };
+        users.unshift(newUser);
+
+        createAuditLog({
+            action: 'User Invited',
+            actor: 'Admin User',
+            target: payload.email,
+            status: 'success',
+            ipAddress: '10.0.0.1',
+        });
+
+        toast.success('Invitation email sent to new user.');
+        return newUser;
+    },
+    updateUserRole: async ({ userId, role }: { userId: string; role: UserRole }): Promise<User> => {
+        await sleep(500);
+        const index = users.findIndex(user => user.id === userId);
+        if (index === -1) {
+            toast.error('User not found.');
+            throw new Error('User not found');
+        }
+
+        users[index] = { ...users[index], role, status: users[index].status ?? 'active' };
+
+        createAuditLog({
+            action: 'Role Updated',
+            actor: 'Admin User',
+            target: users[index].email,
+            status: 'warning',
+            metadata: { role },
+        });
+
+        toast.success('User role updated.');
+        return users[index];
+    },
+    getSystemOverview: async (): Promise<SystemOverview> => {
+        await sleep(500);
+        return {
+            uptime: 99.982,
+            version: 'v2.5.1',
+            lastDeploy: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+            incidentsOpen: 1,
+            nextMaintenance: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(),
+            environment: 'production',
+            services: systemServices,
+        } satisfies SystemOverview;
+    },
+    runHealthCheck: async (): Promise<HealthCheckResult> => {
+        await sleep(700);
+        const baseResults = [
+            {
+                name: 'Database',
+                passed: true,
+                message: 'Replication lag within normal parameters',
+            },
+            {
+                name: 'Message Queue',
+                passed: true,
+                message: 'No backlog detected',
+            },
+            {
+                name: 'Third-Party Payments',
+                passed: systemServices.find(service => service.name === 'Payments')?.status !== 'offline',
+                message: 'Latency slightly higher than baseline',
+            },
+            {
+                name: 'Authentication Provider',
+                passed: true,
+                message: 'Token issuance stable',
+            },
+        ];
+
+        const healthResult: HealthCheckResult = {
+            checkedAt: new Date().toISOString(),
+            results: baseResults,
+            overallStatus: computeHealthStatus(baseResults),
+        };
+
+        createAuditLog({
+            action: 'Health Check Executed',
+            actor: 'Admin User',
+            target: 'Platform',
+            status: healthResult.overallStatus === 'healthy' ? 'success' : 'warning',
+        });
+
+        toast.success('Health check completed.');
+        return healthResult;
+    },
+    getAuditLogs: async (): Promise<AuditLogEntry[]> => {
+        await sleep(400);
+        return [...auditLogs];
+    },
 };

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,55 @@ export interface User {
   email: string;
   role: UserRole;
   avatarUrl?: string;
+  status?: 'active' | 'invited' | 'suspended';
+  lastActive?: string;
+  createdAt?: string;
+}
+
+export type SystemEnvironment = 'production' | 'staging' | 'development';
+
+export type ServiceStatus = 'operational' | 'degraded' | 'offline';
+
+export interface SystemServiceStatus {
+  name: string;
+  status: ServiceStatus;
+  responseTimeMs: number;
+  dependency?: string;
+}
+
+export interface SystemOverview {
+  uptime: number;
+  version: string;
+  lastDeploy: string;
+  incidentsOpen: number;
+  nextMaintenance: string;
+  environment: SystemEnvironment;
+  services: SystemServiceStatus[];
+}
+
+export interface HealthCheckDetail {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+export type HealthStatus = 'healthy' | 'degraded' | 'critical';
+
+export interface HealthCheckResult {
+  checkedAt: string;
+  results: HealthCheckDetail[];
+  overallStatus: HealthStatus;
+}
+
+export interface AuditLogEntry {
+  id: string;
+  action: string;
+  actor: string;
+  target: string;
+  timestamp: string;
+  status: 'success' | 'warning' | 'error';
+  ipAddress?: string;
+  metadata?: Record<string, string | number | boolean>;
 }
 
 export interface Order {


### PR DESCRIPTION
## Summary
- extend domain types and mock API with admin services for invites, role updates, system overview, health checks, and audit logs
- add reusable admin components for inviting users and adjusting roles
- redesign the admin page with team management, diagnostics, service status, and audit insights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caeefad7e88332b9f5e8d37f343235